### PR TITLE
Laravel 4.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support":"~4.1"
+        "illuminate/support":"~4.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
I downgraded `illuminate/support` requirement and tried your (great) package with an old Laravel 4.0 app. It works!

I intend to use this package as a dependency from another package but, unfortunately, I'll have to keep Laravel 4.0 support. Could you merge this PR so we can add Laravel 4.0 compatibility? 

Cheers.
