### PR TITLE
Add Laravel 5.3 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support":"4.*|5.0.*"
+        "illuminate/support": "4.*|~5.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
## Summary of changes:
- Brings conversion into support for all Laravel versions from `4.*` to `5.*`.
- Removed untestable PHP version in `.travis.yml`